### PR TITLE
Trim friendly

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	normal        = "0.1.0"
+	normal        = "0.1.1"
 	preRelease    = "dev"
 	buildRevision string
 

--- a/robot.go
+++ b/robot.go
@@ -60,7 +60,7 @@ var SupportedKeys = map[string]bool{
 	"shift":     true,
 	"ctrl":      true,
 	"alt":       true,
-	" ":         true,
+	"space":     true,
 	"backspace": true,
 	"enter":     true,
 


### PR DESCRIPTION
replace ` ` with `space` to keep keys are available after being trimmed